### PR TITLE
Use akka-seed-1 if it is available, akka-seed-0 otherwise

### DIFF
--- a/kubernetes/akka-seed.yaml
+++ b/kubernetes/akka-seed.yaml
@@ -56,12 +56,11 @@ spec:
 #              apiVersion: v1
 #              fieldPath: status.podIP
         - name: SEED_NODES
-          value: akka-seed-0.akka-seed,akka-seed-1.akka-seed
-        command: ["/bin/sh", "-c", "HOST_NAME=${POD_NAME}.akka-seed java -jar /app/app.jar"]
+          value: akka-seed-1.akka-seed
+        command: ["/bin/bash", "-c", 'test "${POD_NAME}" == "akka-seed-0" && timeout 1 bash -c "cat < /dev/null > /dev/tcp/akka-seed-1.akka-seed/2551" || export SEED_NODES="akka-seed-0.akka-seed,${SEED_NODES}"; HOST_NAME=${POD_NAME}.akka-seed java -jar /app/app.jar']
         livenessProbe:
           tcpSocket:
             port: 2551
         ports:
         - containerPort: 2551
           protocol: TCP
-


### PR DESCRIPTION
For new clusters, the first node needs to talk to itself as its seed node.
For existing clusters, an existing member needs to be contacted.

In order to avoid akka-seed-0 starting new clusters every time it restarts,
nodes contact akka-seed-1 if a cluster already exists there.
Otherwise, a non-existing cluster is assumed and akka-seed-0 becomes
the seed node.

Fixes #2 